### PR TITLE
Support migrated data

### DIFF
--- a/apps/tp-app/functions/index.js
+++ b/apps/tp-app/functions/index.js
@@ -11,6 +11,9 @@ const transformGame = (payload) => {
     const newPayload = {}
     const stackNames = [];
     for(const stack in payload){
+        if(stack === 'MigratedFromOldBlowYourFaceOffSite' && (payload[stack] === true || payload[stack] === 'true')){
+            stackNames.push(stack);
+        }
         if(typeof payload[stack] !== 'object' || Object.keys(stack).some(key => key !== `${parseInt(key)}`)){
             newPayload[stack] = payload[stack];
             continue;

--- a/apps/tp-app/src/views/Search.vue
+++ b/apps/tp-app/src/views/Search.vue
@@ -16,7 +16,8 @@
 
     const route = useRoute();
     const initialQuery = route.query?.q;
-    
+
+    const searchLegacy = ref(false);    
 
     const search = async () => {
         const text = searchBar.value?.value;
@@ -24,14 +25,16 @@
             return;
         }
 
-        if(!searchAs.value){
+        if(!searchAs.value && !searchLegacy.value){
             return;
         }
 
-        const filterObj = / /.test(searchAs.value) ? {
-            filters:`stackNames:"${searchAs.value.replace(/'/,"\\'")}"`
+        const target = searchLegacy.value ? 'MigratedFromOldBlowYourFaceOffSite' : searchAs.value;
+
+        const filterObj = / /.test(target) ? {
+            filters:`stackNames:"${target.replace(/'/,"\\'")}"`
         } : {
-            filters:`stackNames:${searchAs.value.replace(/'/,"\\'")}`
+            filters:`stackNames:${target.replace(/'/,"\\'")}`
         };
 
         const { hits } = await searchIndex.search(text, filterObj);
@@ -71,6 +74,9 @@
         //We may be able to figure out which stack they were looking for if there were multiple in one game, but we'll not assume for now
         location.href = dest;
     }
+    const handleLegacyCheck = (e) => {
+        searchLegacy.value = e.target.checked;
+    }
     onMounted(()=>{
         document.addEventListener('tp-settings-changed',e=>{
             if(e.detail.setting === 'searchAs'){
@@ -87,8 +93,12 @@
     <main>
         <input type='text' ref='searchBar' placeholder="Search"/>
         <button @click="search" :disabled="!searchAs">Search</button>
-        <h3 v-if="!searchAs" class="really needs-backdrop">Search requires a username to try and limit it to games you were a part of. Set your "Search as" username in settings</h3>
-        <p v-else class="really needs-backdrop">Searching as {{ searchAs }}</p>
+        <div class='really needs-backdrop legacy-check'>
+            <h3>Search legacy games:</h3>
+            <input type='checkbox' @click="handleLegacyCheck"/>
+        </div>
+        <h3 v-if="!searchAs && !searchLegacy" class="really needs-backdrop">Search requires a username to try and limit it to games you were a part of. Set your "Search as" username in settings</h3>
+        <p v-else class="really needs-backdrop">Searching <span v-if="searchLegacy">legacy games</span><span v-else>as {{ searchAs }}</span></p>
         <section>
             <article v-for="result in results" @click="e=>handleResultClick(e,result)">
                 <h2>Game {{ result.gameId }}</h2>
@@ -133,5 +143,10 @@
     em {
         background-color: var(--color-important);
         color: white;
+    }
+    .legacy-check {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
     }
 </style>

--- a/packages/byfo-components/src/components/tp-metadata-modal/tp-metadata-modal.tsx
+++ b/packages/byfo-components/src/components/tp-metadata-modal/tp-metadata-modal.tsx
@@ -14,7 +14,7 @@ export class TpMetadataModal {
 
   timeString(ms: number) {
     if (ms < 0) {
-      return '';
+      return 'Unknown round length';
     }
     let seconds = ms / 1000;
     const minutes = Math.floor(seconds / 60);
@@ -33,6 +33,9 @@ export class TpMetadataModal {
   formatDate(date: string) {
     if(date === 'unknown'){
       return 'Unknown'
+    }
+    if(date.startsWith('Migrated')){
+      return date;
     }
     const datePattern = /(?<day>\w{3} \w{3} \d{2} \d{4}) (?<time>[\d:]+) (?<offset>\w{3}[+\-]\d{4}) \((?<timezone>.+)\)/;
     const { groups: parsed } = datePattern.exec(date);

--- a/packages/byfo-components/src/components/tp-review-chat/tp-review-chat.css
+++ b/packages/byfo-components/src/components/tp-review-chat/tp-review-chat.css
@@ -67,6 +67,7 @@ article {
   max-width: 600px;
   max-height: calc(100vh-16rem);
   aspect-ratio: 1.6;
+  background-color: white;
 }
 
 .lightbox {

--- a/packages/byfo-utils/src/firebase.ts
+++ b/packages/byfo-utils/src/firebase.ts
@@ -65,10 +65,13 @@ export class BYFOFirebaseAdapter {
    * @param gameid
    * @returns
    */
-  async getGameData(gameid: number): Promise<BYFO.Game> {
+  async getGameData(gameid: number): Promise<BYFO.GameStacks> {
     const docRef = doc(this.connection.db, `games/${gameid}`);
     const snapshot = await getDocFromServer(docRef);
-    const gameData = snapshot.data() as BYFO.Game;
+    const gameData = snapshot.data() as BYFO.GameStacks;
+    if (gameData['MigratedFromOldBlowYourFaceOffSite']) {
+      delete gameData['MigratedFromOldBlowYourFaceOffSite'];
+    }
     return gameData;
   }
 


### PR DESCRIPTION
A few enhancements to make sure old data is fully supported
- Search query indexing includes a searchable tag for migrated games
- The search page allows you to automatically use this tag
- All review image holders get a white background-color (old images had transparent backgrounds)
- Add a string for unknown round length and games marked "Migrated"